### PR TITLE
Added "mcformat" option to allow for RATPAC output

### DIFF
--- a/sntools/event.py
+++ b/sntools/event.py
@@ -54,7 +54,7 @@ class Event(object):
             dt -= events[i-1].time
         
         s = "%i\n"  % len(self.outgoing_particles)
-        for (pid, e, dirx, diry, dirz) in self.outgoing_particles:
+        for idx, (pid, e, dirx, diry, dirz) in enumerate(self.outgoing_particles):
             mass = 0.0
             if pid == 11 or pid == -11:
                 mass = 0.5109907
@@ -67,5 +67,7 @@ class Event(object):
             px = dirx*p
             py = diry*p
             pz = dirz*p
+            if idx > 0:
+                dt = 0.0
             s += "1 %i 0 0 %.8e %.8e %.8e %.8e %.5e %.5e %.5e %.5e\n" % (pid, px*GeV, py*GeV, pz*GeV, mass*GeV, dt*ns, self.vertex[0]*mm, self.vertex[1]*mm, self.vertex[2]*mm)
         return s

--- a/sntools/event.py
+++ b/sntools/event.py
@@ -35,3 +35,33 @@ class Event(object):
             s += "$ track %i %.5f %.5f %.5f %.5f 0\n" % (pid, e, dirx, diry, dirz)
         s += "$ end\n"
         return s
+
+    def ratpac_string(self, i):
+        """Return RAT-PAC readable HEPEVT-style representation of event for writing to output file.
+
+        Input:
+            i: number of event
+        Output:
+            String describing event."""
+
+        GeV = 0.001   # convert from MeV
+        mm = 10       # convert from cm
+        ns = 1000000  # convert from ms
+        
+        s = "%i\n"  % len(self.outgoing_particles)
+        for (pid, e, dirx, diry, dirz) in self.outgoing_particles:
+            mass = 0.0
+            dt = self.time
+            if pid == 11 or pid == -11:
+                mass = 0.5109907
+            if pid == 22:
+                mass = 0.0
+            if pid == 2112:
+                mass = 939.56563
+            p2 = (e**2) - (mass**2)
+            p = p2**0.5
+            px = dirx*p
+            py = diry*p
+            pz = dirz*p
+            s += "1 %i 0 0 %.8e %.8e %.8e %.8e %.5e %.5e %.5e %.5e\n" % (pid, px*GeV, py*GeV, pz*GeV, mass*GeV, dt*ns, self.vertex[0]*mm, self.vertex[1]*mm, self.vertex[2]*mm)
+        return s

--- a/sntools/event.py
+++ b/sntools/event.py
@@ -36,11 +36,12 @@ class Event(object):
         s += "$ end\n"
         return s
 
-    def ratpac_string(self, i):
+    def ratpac_string(self, i, events):
         """Return RAT-PAC readable HEPEVT-style representation of event for writing to output file.
 
         Input:
             i: number of event
+            events: list of all events
         Output:
             String describing event."""
 
@@ -48,10 +49,13 @@ class Event(object):
         mm = 10       # convert from cm
         ns = 1000000  # convert from ms
         
+        dt = self.time
+        if i > 0:
+            dt -= events[i-1].time
+        
         s = "%i\n"  % len(self.outgoing_particles)
         for (pid, e, dirx, diry, dirz) in self.outgoing_particles:
             mass = 0.0
-            dt = self.time
             if pid == 11 or pid == -11:
                 mass = 0.5109907
             if pid == 22:

--- a/sntools/genevts.py
+++ b/sntools/genevts.py
@@ -79,6 +79,7 @@ def main():
     input = args.input_file
     format = args.format
     output = args.output
+    mcformat = args.mcformat
     distance = args.distance
     starttime = args.starttime if args.starttime else None
     endtime = args.endtime if args.endtime else None
@@ -90,6 +91,7 @@ def main():
         print("hierarchy  =", hierarchy)
         print("input file =", input, "--- format =", format)
         print("output     =", output)
+        print("mcformat   =", mcformat)
         print("detector   =", detector)
         print("distance   =", distance)
         print("starttime  =", starttime)
@@ -127,10 +129,15 @@ def main():
         if verbose:  # write parameters to file as a comment
             outfile.write("# Generated on %s with the options:\n" % datetime.now())
             outfile.write("# " + str(args) + "\n")
-        for (i, evt) in enumerate(events):
-            evt.vertex = detector.generate_random_vertex()
-            outfile.write(evt.nuance_string(i))
-        outfile.write("$ stop\n")
+        if mcformat == 'NUANCE':
+            for (i, evt) in enumerate(events):
+                evt.vertex = detector.generate_random_vertex()
+                outfile.write(evt.nuance_string(i))
+            outfile.write("$ stop\n")
+        if mcformat == 'RATPAC':
+            for (i, evt) in enumerate(events):
+                evt.vertex = detector.generate_random_vertex()
+                outfile.write(evt.ratpac_string(i))
 
 
 def parse_command_line_options():
@@ -148,6 +155,11 @@ def parse_command_line_options():
     default = "outfile.kin"
     parser.add_argument("-o", "--output", metavar="FILE", default=default,
                         help="Name of the output file. Default: '%s'." % default)
+
+    choices = ["NUANCE", "RATPAC"]
+    default = "NUANCE"
+    parser.add_argument("-m", "--mcformat", metavar="MCFORMAT", choices=choices, default=default,
+                        help="MC output format for simulations. Choices: %s. Default: %s." % (choices, default))
 
     choices = ["noosc", "normal", "inverted"]
     default = choices[0]

--- a/sntools/genevts.py
+++ b/sntools/genevts.py
@@ -137,7 +137,7 @@ def main():
         if mcformat == 'RATPAC':
             for (i, evt) in enumerate(events):
                 evt.vertex = detector.generate_random_vertex()
-                outfile.write(evt.ratpac_string(i))
+                outfile.write(evt.ratpac_string(i, events))
 
 
 def parse_command_line_options():


### PR DESCRIPTION
This output format is a HEPEVT-style record for the outgoing particles only
and uses GeV, mm and ns as relevant units; currently only setup for e+/e-,
gammas and neutrons as possible outgoing particles (HEPEVT requires masses)