### PR TITLE
Improved first-run experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ pip install sntools
 to install the latest version of sntools and all dependencies.
 (sntools currently requires at least numpy 1.8, scipy 0.17 and h5py 2.10, but newer versions are recommended.)
 
-You can then run
+Finally, run
 ```
-sntools -h
+python -c 'import sntools; sntools.setup()'
 ```
-for a brief summary of all of sntools’ options.
+to check whether sntools is working and to download the sample input file used below.
 
 ### Example Usage
 
@@ -37,6 +37,12 @@ A more realistic usage that demonstrates more of sntools’ capabilities looks l
 sntools fluxes/intp2001.data --format nakazato --channel es --detector SuperK --distance 20 --verbose --output intp2001es.kin
 ```
 This uses the neutrino flux given in the same input file to generate neutrino-electron elastic scattering events in Super-Kamiokande for a supernova at 20 kpc distance. It also produces more verbose output, which lets you see that sntools generates events separately for different neutrino flavours (which have different fluxes and cross sections), before merging them into an output file named `intp2001es.kin`.
+
+You can also run
+```
+sntools -h
+```
+to get an overview over all of sntools’ options.
 
 
 ## Input

--- a/doc/documentation.tex
+++ b/doc/documentation.tex
@@ -59,7 +59,7 @@ First, make sure you have Python\footnote{Python 3.5 or higher is strongly recom
 (If you don’t, you can get it from \href{https://www.python.org}{python.org} or as part of the \href{https://www.anaconda.com/products/individual}{Anaconda} distribution.)
 
 In a terminal, run \texttt{pip install sntools} to install the latest version of sntools and all dependencies.
-Then, run \texttt{sntools --version} to check whether it’s working.
+Then, run \texttt{python -c 'import sntools; sntools.setup()'} to check whether sntools is working and to download the sample input file used below.
 
 
 \subsection{Quick Start Guide}
@@ -69,7 +69,6 @@ To generate your first supernova neutrino events with sntools, open a terminal w
 \texttt{sntools fluxes/intp2001.data --format nakazato --endtime 50}
 
 This generates events for the first \SI{50}{ms} of a supernova based on the neutrino flux given in the input file \texttt{fluxes/intp2001.data}\footnote{This sample file, which is for a \SI{20}{M_\odot} progenitor from~\cite{Nakazato2013}, is included as part of sntools. See \url{http://asphwww.ph.noda.tus.ac.jp/snn/} for more information.} (which is in the \texttt{nakazato} format) and writes them to a file named \texttt{outfile.kin} in the current directory.
-% TODO: This file is not currently included in the pip-based install.
 
 A more realistic usage that demonstrates more of sntools’ capabilities looks like this:
 

--- a/sntools/__init__.py
+++ b/sntools/__init__.py
@@ -14,3 +14,50 @@ see https://github.com/JostMigenda/sntools.
 """
 
 __version__ = '0.7.0'
+
+
+def setup():
+    """
+    Downloads sample flux file from GitHub if necessary and performs integration test.
+    """
+    print(u"\u2705 sntools was imported from " + __path__[0])
+    import hashlib
+    import os
+    import sys
+    from . import genevts
+
+    flux_dir = 'fluxes/'
+    flux_file = flux_dir + 'intp2001.data'
+    flux_url = 'https://raw.githubusercontent.com/JostMigenda/sntools/master/fluxes/intp2001.data'
+    if os.path.exists(flux_file):
+        print(u"\u2705 Using sample flux file at " + flux_file)
+    else:
+        print(u"\U0001f6e0 Downloading sample flux file from " + flux_url)
+        if not os.path.isdir(flux_dir):
+            os.mkdir(flux_dir)
+        try:
+            from urllib.request import urlretrieve  # Python 3.x
+        except ImportError:
+            from urllib import urlretrieve  # Python 2.7
+        try:
+            urlretrieve(flux_url, filename=flux_file)
+            print(u"\u2705 Saved sample flux file to " + flux_file)
+        except IOError:
+            print(u"\u274c Error: Cannot download sample flux file.")
+            sys.exit(-1)
+
+    print(u"\U0001f6e0 Testing event generation ...")
+    sys.argv += [flux_file, '--format', 'nakazato', '--detector', 'WATCHMAN-LS', '--distance', '2', '--ordering', 'normal', '--starttime', '100', '--endtime', '300', '-o', 'outfile.kin', '--randomseed', '314']
+    genevts.main()
+
+    print(u"\U0001f6e0 Checking output file ...")
+    with open('outfile.kin', 'rb') as f:
+        output_sha = hashlib.sha256(f.read()).hexdigest()
+    
+    test_sha = "6173ea086aab0590212d0207612d57a46184f7569d0205d322fe3b5689f5f700"
+    if output_sha == test_sha:
+        print("\u2705 Everything seems to work fine. Enjoy using sntools!")
+    else:
+        print(u"\u274c Error: Test did not generate the expected events.\n"
+              u"\u274c Please ensure you have installed the most recent version of sntools and all dependencies.\n"
+              u"\u274c If this persists, please go to https://github.com/JostMigenda/sntools and open a new issue.")


### PR DESCRIPTION
Inspired by [this comment](https://github.com/openjournals/joss-reviews/issues/2877#issuecomment-749565380) by @bradkav in the JOSS review.
This adds an `sntools.setup()` function that users should run immediately after installing sntools. It downloads the sample input file used in examples in the documentation and runs an integration test to verify that sntools works and gives the expected results.