### PR TITLE
setup function under Windows

### DIFF
--- a/sntools/__init__.py
+++ b/sntools/__init__.py
@@ -55,8 +55,8 @@ def setup():
 
     tryprint(u"\U0001f6e0")
     print("Checking output file ...")
-    with open('outfile.kin', 'rb') as f:
-        output_sha = hashlib.sha256(f.read()).hexdigest()
+    with open('outfile.kin', 'r') as f:
+        output_sha = hashlib.sha256(f.read().encode('utf-8')).hexdigest()
 
     test_sha = "4424b738d32b6c4baa459fb6fb76d63f944b572a02d319bde4fd247a520f1e29"
     if output_sha == test_sha:


### PR DESCRIPTION
Under Windows, the output file generated by `sntools.setup()` has a different hash value than expected, even though a diff with the `tests/sample_outfile.kin` shows no differences. This is probably due to [different line endings](https://docs.python.org/3.10/library/functions.html#open-newline-parameter); if so, this PR should fix it. 🤞