### PR TITLE
Added options for custom boxes, cylinders and spheres.

### DIFF
--- a/sntools/genevts.py
+++ b/sntools/genevts.py
@@ -18,7 +18,7 @@ except ImportError:
     import sntools
 
 from sntools.channel import gen_evts
-from sntools.detectors import Detector, supported_detectors
+from sntools.detectors import Detector, supported_detectors, supported_materials
 from sntools.formats import CompositeFlux, SNEWPYCompositeFlux
 from sntools.transformation import Transformation, SNEWPYTransformation
 
@@ -99,6 +99,21 @@ def parse_command_line_options():
     parser.add_argument("-d", "--detector", metavar="DETECTOR", choices=supported_detectors, default="HyperK",
                         help="Detector configuration. Choices: %(choices)s. Default: %(default)s.")
 
+    parser.add_argument("-r", "--radius", metavar="R", type=float, default="-1",
+                        help="Radius of custom cylindrical/spherical detector in millimeters.")
+
+    parser.add_argument("-x", "--x", metavar="X", type=float, default="-1",
+                        help="Width in x of custom box detector in millimeters.")
+
+    parser.add_argument("-y", "--y", metavar="Y", type=float, default="-1",
+                        help="Width in y of custom box detector in millimeters.")
+
+    parser.add_argument("-z", "--z", metavar="Z", type=float, default="-1",
+                        help="Height of custom detector in millimeters.")
+
+    parser.add_argument("--material", metavar="MATERIAL", choices=supported_materials, default="water",
+                        help="Custom detector material. Only used for custom detectors. Choices: %(choices)s. Default: %(default)s.")
+
     parser.add_argument("--distance", type=float, default=10.0, help="Distance to supernova in kpc. Default: %(default)s.")
 
     parser.add_argument("--starttime", metavar="T", type=float,
@@ -118,7 +133,7 @@ def parse_command_line_options():
 
     args = parser.parse_args()
 
-    args.detector = Detector(args.detector)
+    args.detector = Detector(args.detector, args.radius, args.x, args.y, args.z, args.material)
     args.channels = args.detector.material["channel_weights"] if args.channel == "all" else [args.channel]
 
     if args.format[:7] == "SNEWPY-":


### PR DESCRIPTION
During the last WATCHMAN study, we had a look at different detector sizes. To facilitate easy use, I have added the capability to run custom detector sizes and fills, defined from the command line. It should still perform as before for the already defined detectors. Since it was a straightforward addition, I also allowed for spherical designs, this might be useful for SNO+, for example. This might need more work to be in line with @svalder recent pull request #41 - and adjustments of the unit tests.

Please have a look and check whether this is useful. If so, let me know and I can update the documentation and unit tests accordingly.

This also replaces the closed PR #42 with the messy history.
