### PR TITLE
add support for Python 3.11, drop 3.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This README file should give a brief overview over sntools and help you get star
 
 ## Getting Started
 ### Installation Instructions
-First, make sure you have Python 3.7 or higher installed on your computer.
+First, make sure you have Python 3.8 or higher installed on your computer.
 Then, in a terminal, run
 ```
 pip install sntools

--- a/doc/documentation.tex
+++ b/doc/documentation.tex
@@ -59,7 +59,7 @@ Additionally, sntools can be used as a Python library that implements neutrino c
 % sntools should support *at least* the python/scipy/numpy versions required by NEP 29:
 % https://numpy.org/neps/nep-0029-deprecation_policy.html
 
-First, make sure you have Python 3.6 or higher installed on your computer.
+First, make sure you have Python 3.8 or higher installed on your computer.
 (If you don’t, you can get it from \href{https://www.python.org}{python.org} or as part of the \href{https://www.anaconda.com/products/individual}{Anaconda} distribution.)
 
 In a terminal, run \texttt{pip install sntools} to install the latest version of sntools and all dependencies.

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,10 @@ setup(
         # checked by 'pip install'. See instead 'python_requires' below.
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     # Comma-separated list of keywords which will appear on the PyPI project
@@ -85,7 +85,7 @@ setup(
     # and refuse to install the project if the version does not match. See
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
     # When the supported version changes, remember to also update `classifiers` above!
-    python_requires='>=3.7, <4',
+    python_requires='>=3.8, <4',
 
     # This field lists other packages that your project depends on to run.
     # These packages will be installed by pip when your project is installed.


### PR DESCRIPTION
In line with [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html).