### PR TITLE
drop support for Python 3.8, add 3.13 to testing matrix

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This README file should give a brief overview over sntools and help you get star
 
 ## Getting Started
 ### Installation Instructions
-First, make sure you have Python 3.8 or higher installed on your computer.
+First, make sure you have Python 3.9 or higher installed on your computer.
 Then, in a terminal, run
 ```
 pip install sntools

--- a/doc/documentation.tex
+++ b/doc/documentation.tex
@@ -59,7 +59,7 @@ Additionally, sntools can be used as a Python library that implements neutrino c
 % sntools should support *at least* the python/scipy/numpy versions required by NEP 29:
 % https://numpy.org/neps/nep-0029-deprecation_policy.html
 
-First, make sure you have Python 3.8 or higher installed on your computer.
+First, make sure you have Python 3.9 or higher installed on your computer.
 (If you don’t, you can get it from \href{https://www.python.org}{python.org} or as part of the \href{https://www.anaconda.com/products/individual}{Anaconda} distribution.)
 
 In a terminal, run \texttt{pip install sntools} to install the latest version of sntools and all dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Event generator for supernova burst neutrinos"
 readme = "README.md"
 license = {file = "LICENSE"}
 
-requires-python = ">=3.8"  # TODO: Also update classifiers below!
+requires-python = ">=3.9"  # TODO: Also update classifiers below!
 dependencies = [
     "numpy",
     "scipy",
@@ -35,11 +35,11 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 
 


### PR DESCRIPTION
This matches the support matrix of snewpy v1.6.