### PR TITLE
exclude incompatible uproot versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "scipy",
     "h5py >= 2.10",
     "snewpy ~=1.6.0",
-    "uproot"
+    "uproot !=5.6.7,!=5.6.8,!=5.6.9,!=5.7.0,!=5.7.1,!=5.7.2"
 ]
 
 keywords = ["astrophysics", "supernova", "neutrino", "event generator"]


### PR DESCRIPTION
Fixes #68.

It’s slightly awkward to exclude these versions one by one, but since uproot v5.7.3 no longer supports Python 3.9, we can’t simplify that to `uproot >=5.7.3` yet.